### PR TITLE
Supported `+` and `|` operators for `Files`

### DIFF
--- a/base/dataset.py
+++ b/base/dataset.py
@@ -43,7 +43,9 @@ class Dataset:
         filepath used to test
     """
 
-    def __init__(self, files: Files, target_key: str, transform: Optional[Callable] = None) -> None:
+    def __init__(
+        self, files: Files, target_key: str, transform: Optional[Callable] = None
+    ) -> None:
         """
         Make the dict to convert labels to numbers.
 

--- a/base/files.py
+++ b/base/files.py
@@ -3,6 +3,7 @@
 # Copyright 2022 Adansons Inc.
 # Please contact engineer@adansons.co.jp
 import os
+import re
 import json
 import copy
 import requests
@@ -100,7 +101,14 @@ class Files:
         self.user_id = get_user_id()
         self.project_uid = get_project_uid(self.user_id, project_name)
 
+        self.sort_key = sort_key
+        self.conditions = conditions
+        self.query = query
+
         self.__export(conditions=conditions, query=query, sort_key=sort_key)
+
+        self.reprtext = self.__reprtext_generator()
+        self.expression = self.__class__.__name__
 
     def __search(
         self, conditions: Optional[str] = None, query: List[str] = []
@@ -170,10 +178,6 @@ class Files:
         """
         # arguments varidation
         self.__validate_args(conditions, query, sort_key)
-
-        self.sort_key = sort_key
-        self.conditions = conditions
-        self.query = query
 
         result = self.__search(conditions, query)
         if sort_key is not None:
@@ -364,14 +368,95 @@ class Files:
     def __repr_formatter(self, string: Optional[str]) -> Optional[str]:
         return "'" + string + "'" if string is not None else None
 
-    def __repr__(self) -> str:
+    def __reprtext_generator(self) -> str:
         project_name = self.__repr_formatter(self.project_name)
         conditions = self.__repr_formatter(self.conditions)
-        query = self.__repr_formatter(
-            None if len(self.query) == 0 else "&".join(self.query)
-        )
+        query = self.query
         sort_key = self.__repr_formatter(self.sort_key)
-        return f"{self.__class__.__name__}(project_name={project_name}, conditions={conditions}, query={query}, sort_key={sort_key}, file_num={len(self.files)})"
+        reprtext = f"{self.__class__.__name__}(project_name={project_name}, conditions={conditions}, query={query}, sort_key={sort_key}, file_num={len(self.files)})\n"
+        return reprtext
+
+    def __repr__(self) -> str:
+        # if this instance is operated,
+        if self.reprtext.count(self.__class__.__name__) >= 2:
+            repr_header = "======Files======\n"
+            expres_header = "===Expressions===\n"
+            # number each File instance
+            self.reprtext = re.sub(
+                f"{self.__class__.__name__}[0-9]*", "{}", self.reprtext
+            )
+            self.expression = re.sub(
+                f"{self.__class__.__name__}[0-9]*", "{}", self.expression
+            )
+            self.reprtext = self.reprtext.format(
+                *[
+                    f"{self.__class__.__name__}{i+1}"
+                    for i in range(self.reprtext.count("{}"))
+                ]
+            )
+            self.expression = self.expression.format(
+                *[
+                    f"{self.__class__.__name__}{i+1}"
+                    for i in range(self.expression.count("{}"))
+                ]
+            )
+            return repr_header + self.reprtext + expres_header + self.expression
+        else:
+            return self.reprtext
+
+    def __add__(self, other: "Files") -> "Files":
+        if isinstance(other, self.__class__):
+            files = copy.copy(self)
+            files.result = self.result + other.result
+            files.__set_attributes(files.result)
+            files.reprtext = files.reprtext + other.reprtext
+            files.expression += " + " + other.expression
+            files.conditions = self.conditions + "," + other.conditions
+            files.query = sorted(
+                set([*(self.query), *(other.query)]),
+                key=[*(self.query), *(other.query)].index,
+            )
+            return files
+        else:
+            raise TypeError(
+                f"unsupported operand type(s) for +: '{self.__class__.__name__}' and '{other.__class__.__name__}'."
+            )
+
+    def __or__(self, other: "Files") -> "Files":
+        if isinstance(other, self.__class__):
+            files = copy.copy(self)
+            uniq_result = list(
+                set(
+                    map(
+                        lambda x: json.dumps(sorted(x.items())),
+                        [*(self.result), *(other.result)],
+                    )
+                ),
+            )
+            files.result = [dict(json.loads(result)) for result in uniq_result]
+            files.__set_attributes(files.result)
+
+            files.reprtext = files.reprtext + other.reprtext
+            files_expression_count = files.expression.count(files.__class__.__name__)
+            other_expression_count = other.expression.count(other.__class__.__name__)
+            if files_expression_count >= 2 and other_expression_count >= 2:
+                files.expression = f"({files.expression}) or ({other.expression})"
+            elif files_expression_count == 1 and other_expression_count >= 2:
+                files.expression = f"{files.expression} or ({other.expression})"
+            elif files_expression_count >= 2 and other_expression_count == 1:
+                files.expression = f"({files.expression}) or {other.expression}"
+            elif files_expression_count == 1 and other_expression_count == 1:
+                files.expression = f"{files.expression} or {other.expression}"
+            files.conditions = self.conditions + "," + other.conditions
+            files.query = sorted(
+                set([*(self.query), *(other.query)]),
+                key=[*(self.query), *(other.query)].index,
+            )
+            return files
+        else:
+            raise TypeError(
+                f"unsupported operand type(s) for +: '{self.__class__.__name__}' and '{other.__class__.__name__}'."
+            )
 
 
 if __name__ == "__main__":

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -453,6 +453,76 @@ This method apply additional filter to already filtered Files object. You can us
 
 - Files class
 
+There are available operators
+
+ - [＋ (concatenation)](#+-(concatenatopm))
+ - [| (union)](#|-(union))
+
+ ### **+ (concatenation)**
+Return a new Files object that is the concatenataion of the 2 Files object. You can use this operator recursively.
+
+This operation is **not** sensitive to element duplication. If both Files objects has same File object, the operated Files object has 2 same File object.
+
+**Expression**
+```python
+concated_files = files1 + files2
+
+# You can operate recursively.
+concated_files = files1 + files2 + files3
+concated_files2 = concated_files + files4
+```
+
+**Examples**
+ ```python
+files1 = project.files(conditions="20220418", query=["hour >= 018"], sort_key="hour")
+files2 = project.files(conditions="20220419", query=["hour >= 021"], sort_key="hour")
+
+files = files1 + files2
+print(files)
+>>> ======Files======
+     Files1(project_name="project-name", conditions="20220418", query=["hour >= 018"], sort_key="hour", file_num=160)
+     Files2(project_name="project-name", conditions="20220419", query=["hour >= 021"], sort_key="hour", file_num=100)
+     ===Expressions===
+     Files1 + Files2
+
+print(len(files))
+>>> 260
+ ```
+
+
+ ### **| (union)**
+Return a new Files object that is the union of the 2 Files object. You can use this operator recursively.
+
+This operation guaranteed that all File objects that operated Files object has are unique.
+
+**Expression**
+```python
+union_files = files1 | files2
+
+# You can operate recursively.
+union_files = files1 | files2 | files3
+union_files2 = union_files | files4
+```
+
+**Examples**
+ ```python
+files1 = project.files(query=["hour >= 020"], sort_key="hour")
+files2 = project.files(conditions="20220426,20220429", query=["hour >= 17"], sort_key="hour")
+
+files = files1 + files2
+print(files)
+>>> ======Files======
+     Files1(project_name="project-name", conditions=None, query=["hour >= 020"], sort_key="hour", file_num=650)
+     Files2(project_name="project-name", conditions="20220426,20220429", query=["hour >= 017"], sort_key="hour", file_num=200)
+     ===Expressions===
+     Files1 or Files2
+
+print(len(files))
+>>> 710
+ ```
+
+
+
 → [Back to top](#python-reference)
 
 ## **calc_file_hash()**


### PR DESCRIPTION
close #29

# Motivation

# Description of the changes
we will be able to  operate Files instance with `+` and `|` as bellow!!!

# Example
```python
project = Project("hoge")
files1 = project.files(conditions="20220418", query=["hour >= 018"], sort_key='hour')
files2 = project.files(conditions="20220419", sort_key='hour')
files3 = project.files(conditions="20220420", query=["hour <= 009"], sort_key='hour')

# we can use `+` operator, and `add_files.files` has list of 3`.files` directly extended.
add_files = files1 + files2 + files3
print(add_files)
>>> ======Files======
    Files1(project_name='glia', conditions='20220418', query=['hour >= 018'], sort_key='hour', file_num=6)
    Files2(project_name='glia', conditions='20220419', query=[], sort_key='hour', file_num=24)
    Files3(project_name='glia', conditions='20220420', query=['hour <= 009'], sort_key='hour', file_num=10)
    ===Expressions===
    Files1 + Files2 + Files3

print(len(add_files))
>>> 40


files4 = project.files(conditions="20220427,20220428,20220429", query=["hour < 005"], sort_key='date')
files5 = project.files(conditions="20220429", sort_key='hour')

# we can use `|` operator, and `or_files.files` has list of or_set of 2`.files`.
or_files = files4 | files5
print(or_files)
>>>======Files======
  Files1(project_name='glia', conditions='20220427,20220428,20220429', query=['hour < 005'], sort_key='date', file_num=15)
  Files2(project_name='glia', conditions='20220429', query=[], sort_key='hour', file_num=24)
  ===Expressions===
  Files1 or Files2

print(len(or_files))
>>> 34
```