### PR TITLE
Added `.metadata` attr to `File`

### DIFF
--- a/base/dataset.py
+++ b/base/dataset.py
@@ -43,7 +43,9 @@ class Dataset:
         filepath used to test
     """
 
-    def __init__(self, files: Files, target_key: str, transform: Optional[Callable] = None) -> None:
+    def __init__(
+        self, files: Files, target_key: str, transform: Optional[Callable] = None
+    ) -> None:
         """
         Make the dict to convert labels to numbers.
 

--- a/base/files.py
+++ b/base/files.py
@@ -39,6 +39,7 @@ class File(str):
     def __new__(cls, file_path: str, attrs: dict):
         self = super().__new__(cls, file_path)
         self.path = file_path
+        self.metadata = attrs
         self.__dict__.update(attrs)
         return self
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -284,6 +284,20 @@ These are the available attributes:
     >>> "/home/xxxx/dataset/mnist/0/12909.png"
     ```
     
+- metadata (dict)
+    whole dict of attributes (metadata) which related with this file.
+    
+    For example:
+    
+    ```Python
+    files[0].metadata
+    >>> {
+            "dataType": "train",
+            "label": "0",
+            "id": "12909"
+        }
+    ```
+    
 - attrs (dict)
     - attributes (metadata) which related with this file.
     


### PR DESCRIPTION
close #45 

# Motivation
now we can reference the dict of metadata in File with `.__dict__` attr, and it is not friendly.

# Description of the changes

we can reference metadata with `.metadata` attr 👍 
```python
project = Project("project")
files1 = project.files(conditions="20220418", query=["hour >= 018"])

print(obj[0].metadata)
>>>{
    'date': 20220418,
    'PMT1_LED505': 0.147,
    'hour': '023',
    'PMT1_LED420': 0.0298,
    'PMT2_LED420': 0.0903,
    'animal': 'YT001'
   }
```
