### PR TITLE
Fixed error statements when parsing fails.

### DIFF
--- a/base/cli.py
+++ b/base/cli.py
@@ -404,7 +404,7 @@ path to your file: {sample_file_path}"
     except ValueError as e:
         print(e)
         click.echo(
-            f"\nCan't parse uniquely with parsing rule: {parse}.\n\
+            f"\nCan't parse uniquely with parsing rule: {parse}\n\
 Please tell me detail parsing rule in accordance with the actual path.\n\
 * use {{value}} to parse phrases with value in the actual path\n\
 * put {{}} before/after the value corresponding to {{_}} on the original parsing rule.\n\

--- a/base/dataset.py
+++ b/base/dataset.py
@@ -43,7 +43,9 @@ class Dataset:
         filepath used to test
     """
 
-    def __init__(self, files: Files, target_key: str, transform: Optional[Callable] = None) -> None:
+    def __init__(
+        self, files: Files, target_key: str, transform: Optional[Callable] = None
+    ) -> None:
         """
         Make the dict to convert labels to numbers.
 


### PR DESCRIPTION
close #44

# Motivation
when parsing fails, we get Can't parse uniquely with parsing rule: {xxxx}/{_}/{xxxx}_{xxxx}.csv..
I think the comma after the extension is not necessary.
