### PR TITLE
add parser.validate_parsing_rule

### DIFF
--- a/base/parser.py
+++ b/base/parser.py
@@ -119,7 +119,7 @@ class Parser:
 
         parsed_dict = {}
         for key, value in zip(self.parsing_keys, parsed_values):
-            if key in  ["_", "[UnuseToken]"]:
+            if key in ["_", "[UnuseToken]"]:
                 continue
             parsed_dict[key] = value
 
@@ -333,8 +333,8 @@ class Parser:
             )
 
         return path
-    
-    def validate_parsing_rule(self)->bool:
+
+    def validate_parsing_rule(self) -> bool:
         """
         Check that the parsing_rule is valid
         Parameter
@@ -347,12 +347,11 @@ class Parser:
         """
         if len(self.parsing_keys) == 0:
             is_valid = False
-        elif len(self.parsing_keys) == 1 and self.parsing_keys[0] == '[UnuseToken]':
+        elif len(self.parsing_keys) == 1 and self.parsing_keys[0] == "[UnuseToken]":
             is_valid = False
         else:
             is_valid = True
         return is_valid
-
 
 
 if __name__ == "__main__":

--- a/base/parser.py
+++ b/base/parser.py
@@ -119,7 +119,7 @@ class Parser:
 
         parsed_dict = {}
         for key, value in zip(self.parsing_keys, parsed_values):
-            if key == "_":
+            if key in  ["_", "[UnuseToken]"]:
                 continue
             parsed_dict[key] = value
 
@@ -170,7 +170,7 @@ class Parser:
         self.unuse_strs = self.extract_unuse_str()
 
         for not_use_str in self.unuse_strs:
-            self.parsing_rule = self.parsing_rule.replace(not_use_str, "{_}")
+            self.parsing_rule = self.parsing_rule.replace(not_use_str, "{[UnuseToken]}")
 
         self.parsing_rule = self.parsing_rule.replace("}{", "}" + self.sep + "{")
 
@@ -333,6 +333,26 @@ class Parser:
             )
 
         return path
+    
+    def validate_parsing_rule(self)->bool:
+        """
+        Check that the parsing_rule is valid
+        Parameter
+        ----------------
+        self.parsing_keys
+
+        Return
+        ----------------
+        is_valid : bool
+        """
+        if len(self.parsing_keys) == 0:
+            is_valid = False
+        elif len(self.parsing_keys) == 1 and self.parsing_keys[0] == '[UnuseToken]':
+            is_valid = False
+        else:
+            is_valid = True
+        return is_valid
+
 
 
 if __name__ == "__main__":

--- a/base/project.py
+++ b/base/project.py
@@ -346,7 +346,11 @@ class Project:
             parser = Parser(parsing_rule)
             if detail_parsing_rule is not None:
                 parser.update_rule(detail_parsing_rule)
-
+            if not parser.validate_parsing_rule():
+                raise Exception(
+                    f"This parsing rule is not valid.\n\
+Make sure that the key is enclosed with `{{}}` in the parsing_rule."
+                )
             if not parser.is_path_parsable(
                 files[0].split(dir_path)[-1].replace(os.sep, "/")
             ):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,14 +24,32 @@ PARSED_DICT1 = {
 
 INPUT_PATH2 = "Origin/hoge1/fugasuzukipiyo_03.csv"
 PARSING_RULE2 = "{_}/hoge{num1}/fuga{name}piyo_{month}.csv"
-CONVERTED_PARSING_RULE2 = "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.csv"
-PARSING_KEYS2 = ["_", "[UnuseToken]", "num1", "[UnuseToken]", "name", "[UnuseToken]", "month"]
+CONVERTED_PARSING_RULE2 = (
+    "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.csv"
+)
+PARSING_KEYS2 = [
+    "_",
+    "[UnuseToken]",
+    "num1",
+    "[UnuseToken]",
+    "name",
+    "[UnuseToken]",
+    "month",
+]
 PARSED_DICT2 = {"num1": "1", "name": "suzuki", "month": "03"}
 
 INPUT_PATH3 = "Origin/hoge1/fugasuzukipiyo_2022_03_02.csv"
 PARSING_RULE3 = "{_}/hoge{num1}/fuga{name}piyo_{timestamp}.csv"
 DETAIL_PARSING_RULE = "{Origin}/hoge{1}/fuga{suzuki}piyo_{2022_03_02}.csv"
-PARSING_KEYS3 = ["_", "[UnuseToken]", "num1", "[UnuseToken]", "name", "[UnuseToken]", "timestamp"]
+PARSING_KEYS3 = [
+    "_",
+    "[UnuseToken]",
+    "num1",
+    "[UnuseToken]",
+    "name",
+    "[UnuseToken]",
+    "timestamp",
+]
 PARSED_DICT3 = {"num1": "1", "name": "suzuki", "timestamp": "2022_03_02"}
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,14 +24,14 @@ PARSED_DICT1 = {
 
 INPUT_PATH2 = "Origin/hoge1/fugasuzukipiyo_03.csv"
 PARSING_RULE2 = "{_}/hoge{num1}/fuga{name}piyo_{month}.csv"
-CONVERTED_PARSING_RULE2 = "{_}/{_}/{num1}/{_}/{name}/{_}_{month}.csv"
-PARSING_KEYS2 = ["_", "_", "num1", "_", "name", "_", "month"]
+CONVERTED_PARSING_RULE2 = "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.csv"
+PARSING_KEYS2 = ["_", "[UnuseToken]", "num1", "[UnuseToken]", "name", "[UnuseToken]", "month"]
 PARSED_DICT2 = {"num1": "1", "name": "suzuki", "month": "03"}
 
 INPUT_PATH3 = "Origin/hoge1/fugasuzukipiyo_2022_03_02.csv"
 PARSING_RULE3 = "{_}/hoge{num1}/fuga{name}piyo_{timestamp}.csv"
 DETAIL_PARSING_RULE = "{Origin}/hoge{1}/fuga{suzuki}piyo_{2022_03_02}.csv"
-PARSING_KEYS3 = ["_", "_", "num1", "_", "name", "_", "timestamp"]
+PARSING_KEYS3 = ["_", "[UnuseToken]", "num1", "[UnuseToken]", "name", "[UnuseToken]", "timestamp"]
 PARSED_DICT3 = {"num1": "1", "name": "suzuki", "timestamp": "2022_03_02"}
 
 


### PR DESCRIPTION
close #69 

# Motivation
When input a parsing_rule not including the pattern `{XX}`, an error should be printed, but "Success!"
# Description of the changes
* add `Parser.validate_parsing_rule`
* check parsing_rule is valid in `Project.add_datafiles`
# Example