### PR TITLE
create custom exceptions for click commands

### DIFF
--- a/base/cli.py
+++ b/base/cli.py
@@ -28,6 +28,7 @@ from base.config import (
     update_project_info,
     get_user_id_from_db,
 )
+from .exception import CatchAllExceptions, search_export_exception
 
 
 def base_config(func):
@@ -564,7 +565,11 @@ def import_metafile(
         click.echo("Success!")
 
 
-@main.command(name="search", help="search files")
+@main.command(
+    name="search",
+    help="search files",
+    cls=CatchAllExceptions(click.Command, handler=search_export_exception),
+)
 @click.argument("project")
 @click.option(
     "-q",

--- a/base/exception.py
+++ b/base/exception.py
@@ -1,0 +1,69 @@
+import click
+
+
+def CatchAllExceptions(cls, handler):
+    """
+    Function to override the default exception handler of click.
+    With thanks to this Stack Overflow answer:
+    https://stackoverflow.com/questions/52213375/python-click-exception-handling-under-setuptools
+
+    Parameters
+    ----------
+    cls : The class that the handler is being applied e.g. click.Command
+    handler : The handler function to print the error message
+
+    Returns
+    -------
+    Cls : The new class itself with the handler applied
+    """
+
+    class Cls(cls):
+        _original_args = None
+
+        def make_context(self, info_name, args, parent=None, **extra):
+
+            # grab the original command line arguments
+            self._original_args = " ".join(args)
+
+            try:
+                return super(Cls, self).make_context(
+                    info_name, args, parent=parent, **extra
+                )
+            except Exception as exc:
+                # call the handler
+                handler(self, info_name, exc)
+                # let the user see the original error
+                raise
+
+        def invoke(self, ctx):
+            try:
+                return super(Cls, self).invoke(ctx)
+            except Exception as exc:
+                # call the handler
+                handler(self, ctx.info_name, exc)
+
+                # let the user see the original error
+                raise
+
+    return Cls
+
+
+def search_export_exception(cmd, info_name, exc):
+    """
+    Function to handle the exception for "base search --export" command.
+
+    Parameters
+    ----------
+    cmd: The command that user is trying to run
+    info_name: The name of the exception
+    exc: The exception message
+
+    Returns
+    -------
+    None
+    """
+    # send error info to rollbar, etc, here
+    if "'--export' requires an argument" or "'--e' requires an argument" in str(exc):
+        click.echo("You can specify ‘json’ or ‘csv’ as export-file-type")
+    else:
+        click.echo("Raised error: {}".format(exc))

--- a/base/exception.py
+++ b/base/exception.py
@@ -63,7 +63,7 @@ def search_export_exception(cmd, info_name, exc):
     None
     """
     # send error info to rollbar, etc, here
-    if "'--export' requires an argument" or "'--e' requires an argument" in str(exc):
+    if ("'--export' requires an argument" or "'--e' requires an argument") in str(exc):
         click.echo("You can specify ‘json’ or ‘csv’ as export-file-type")
     else:
         click.echo("Raised error: {}".format(exc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,7 +335,7 @@ def test_search_files_export_exception():
     time.sleep(5)
     runner = CliRunner()
     result = runner.invoke(search_files, [PROJECT_NAME, "--export"])
-    assert "You can specify ‘json’" or "‘csv’ as export-file-type" in result.output
+    assert "You can specify ‘json’ or ‘csv’ as export-file-type" in result.output
 
 
 def test_get_project_member():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@
 import os
 
 import time
+from unittest import result, runner
 from click.testing import CliRunner
 from base.cli import (
     create_table,
@@ -328,6 +329,13 @@ def test_search_files():
     result = runner.invoke(search_files, [PROJECT_NAME, "-q", "title == sample"])
     assert result.exit_code == 0
     assert "1 files" in result.output
+
+
+def test_search_files_export_exception():
+    time.sleep(5)
+    runner = CliRunner()
+    result = runner.invoke(search_files, [PROJECT_NAME, "--export"])
+    assert "You can specify ‘json’ or ‘csv’ as export-file-type" in result.output
 
 
 def test_get_project_member():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,7 +335,7 @@ def test_search_files_export_exception():
     time.sleep(5)
     runner = CliRunner()
     result = runner.invoke(search_files, [PROJECT_NAME, "--export"])
-    assert "You can specify ‘json’ or ‘csv’ as export-file-type" in result.output
+    assert "You can specify ‘json’" or "‘csv’ as export-file-type" in result.output
 
 
 def test_get_project_member():


### PR DESCRIPTION
close #85 

# Motivation
Make default error messages in CLICK easier to understand for BASE users

# Description of the changes
- Add an exception file to override the click class
- Add a test for a new exception

# Example