### PR TITLE
base search {project} --o, change default CLICK exception

### DIFF
--- a/base/exception.py
+++ b/base/exception.py
@@ -65,5 +65,9 @@ def search_export_exception(cmd, info_name, exc):
     # send error info to rollbar, etc, here
     if ("'--export' requires an argument" or "'--e' requires an argument") in str(exc):
         click.echo("You can specify ‘json’ or ‘csv’ as export-file-type")
+    elif ("'--output' requires an argument" or "'--o' requires an argument") in str(
+        exc
+    ):
+        click.echo("You can specify the output file name")
     else:
         click.echo("Raised error: {}".format(exc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,13 +331,6 @@ def test_search_files():
     assert "1 files" in result.output
 
 
-def test_search_files_export_exception():
-    time.sleep(5)
-    runner = CliRunner()
-    result = runner.invoke(search_files, [PROJECT_NAME, "--export"])
-    assert "You can specify ‘json’ or ‘csv’ as export-file-type" in result.output
-
-
 def test_get_project_member():
     runner = CliRunner()
     result = runner.invoke(show_project_detail, [PROJECT_NAME, "--member-list"])


### PR DESCRIPTION
close #95 

# Motivation
Make default error messages in CLICK easier to understand for BASE users

# Description of the changes
- add a condition that users don't input the output file path
- remove the test for an exception, they are too detailed.

# Example