### PR TITLE
fix is_path_parsable and fix the case of multiple extension

### DIFF
--- a/base/parser.py
+++ b/base/parser.py
@@ -32,7 +32,9 @@ class Parser:
         Then, self.unuse_strs is `["hoge", "fuga"]`.
     """
 
-    def __init__(self, parsing_rule: str, extension: str, sep: Optional[str] = None) -> None:
+    def __init__(
+        self, parsing_rule: str, extension: str, sep: Optional[str] = None
+    ) -> None:
         """
         Parameters
         ----------
@@ -171,8 +173,8 @@ class Parser:
         parsable_parsing_rule: str
             ex.) `{_}/{num1}/{fuga}/{num2}.txt`
         """
-        if not self.parsing_rule.endswith("."+self.extension):
-            self.parsing_rule += "."+self.extension
+        if not self.parsing_rule.endswith("." + self.extension):
+            self.parsing_rule += "." + self.extension
 
         self.unuse_strs = self.extract_unuse_str()
 
@@ -325,10 +327,10 @@ class Parser:
             path = path.replace(unuse_str, self.sep + unuse_str + self.sep)
 
         path = path.replace(self.sep * 3, self.sep)
-        
+
         splitters = sorted(list(set(self.splitters)))
 
-        # Put "/" at the last position in `splitters`        
+        # Put "/" at the last position in `splitters`
         if self.sep in splitters:
             splitters.remove(self.sep)
             splitters.append(self.sep)

--- a/base/project.py
+++ b/base/project.py
@@ -368,15 +368,17 @@ Make sure that the key is enclosed with `{{}}` in the parsing_rule."
             meta_data = {}
 
             # calculation hash value and update meta data dictionary
-            hash_value = calc_file_hash(f)
+            hash_value = calc_file_hash(file)
             meta_data["FileHash"] = hash_value
             hash_dict[hash_value] = (
-                os.path.abspath(f).replace(os.sep, "/").replace("/", os.sep)
+                os.path.abspath(file).replace(os.sep, "/").replace("/", os.sep)
             )
             meta_data.update(attributes)
 
             if parser is not None:
-                meta_data_from_path = parser(f.split(dir_path)[-1].replace(os.sep, "/"))
+                meta_data_from_path = parser(
+                    file.split(dir_path)[-1].replace(os.sep, "/")
+                )
                 meta_data.update(meta_data_from_path)
 
             data_list.append(meta_data)

--- a/base/project.py
+++ b/base/project.py
@@ -11,7 +11,6 @@ import base64
 import requests
 from typing import Optional, List, Union
 import time
-import concurrent.futures
 from colorama import Fore, init
 
 from base.files import Files
@@ -348,7 +347,7 @@ class Project:
 
         parser = None
         if parsing_rule is not None:
-            parser = Parser(parsing_rule)
+            parser = Parser(parsing_rule, extension=extension)
             if detail_parsing_rule is not None:
                 parser.update_rule(detail_parsing_rule)
             if not parser.validate_parsing_rule():
@@ -363,33 +362,22 @@ Make sure that the key is enclosed with `{{}}` in the parsing_rule."
                     "Failed to parse path with specified rule. tell me detail parsing rule."
                 )
 
-        hash_dict = {}
-
-        def calc_hash(file):
+        for f in files:
             meta_data = {}
 
             # calculation hash value and update meta data dictionary
-            hash_value = calc_file_hash(file)
+            hash_value = calc_file_hash(f)
             meta_data["FileHash"] = hash_value
             hash_dict[hash_value] = (
-                os.path.abspath(file).replace(os.sep, "/").replace("/", os.sep)
+                os.path.abspath(f).replace(os.sep, "/").replace("/", os.sep)
             )
             meta_data.update(attributes)
 
             if parser is not None:
-                meta_data_from_path = parser(
-                    file.split(dir_path)[-1].replace(os.sep, "/")
-                )
+                meta_data_from_path = parser(f.split(dir_path)[-1].replace(os.sep, "/"))
                 meta_data.update(meta_data_from_path)
 
             data_list.append(meta_data)
-
-        print("Calculate filehash...")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            for file in files:
-                executor.submit(calc_hash, file)
-        print()
-
         # create local datafile linker
         linked_hash_location = os.path.join(
             LINKER_DIR, self.project_uid, "linked_hash.json"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,9 +12,9 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from base.parser import Parser
 
 
-INPUT_PATH1 = "Origin/左声帯嚢胞/1-055-E-a01.wav"
+INPUT_PATH1 = "/Origin/左声帯嚢胞/1-055-E-a01.wav"
 PARSING_RULE1 = "{_}/{disease}/{_}-{patient-id}-{part}-{iteration}.wav"
-PARSING_KEYS1 = ["_", "disease", "_", "patient-id", "part", "iteration"]
+PARSING_KEYS1 = ["_", "disease", "_", "patient-id", "part", "iteration", "[UnuseToken]"]
 PARSED_DICT1 = {
     "disease": "左声帯嚢胞",
     "patient-id": "055",
@@ -22,10 +22,10 @@ PARSED_DICT1 = {
     "iteration": "a01",
 }
 
-INPUT_PATH2 = "Origin/hoge1/fugasuzukipiyo_03.csv"
+INPUT_PATH2 = "/Origin/hoge1/fugasuzukipiyo_03.csv"
 PARSING_RULE2 = "{_}/hoge{num1}/fuga{name}piyo_{month}.csv"
 CONVERTED_PARSING_RULE2 = (
-    "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.csv"
+    "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.{[UnuseToken]}"
 )
 PARSING_KEYS2 = [
     "_",
@@ -35,10 +35,11 @@ PARSING_KEYS2 = [
     "name",
     "[UnuseToken]",
     "month",
+    "[UnuseToken]"
 ]
 PARSED_DICT2 = {"num1": "1", "name": "suzuki", "month": "03"}
 
-INPUT_PATH3 = "Origin/hoge1/fugasuzukipiyo_2022_03_02.csv"
+INPUT_PATH3 = "/Origin/hoge1/fugasuzukipiyo_2022_03_02.csv"
 PARSING_RULE3 = "{_}/hoge{num1}/fuga{name}piyo_{timestamp}.csv"
 DETAIL_PARSING_RULE = "{Origin}/hoge{1}/fuga{suzuki}piyo_{2022_03_02}.csv"
 PARSING_KEYS3 = [
@@ -49,48 +50,49 @@ PARSING_KEYS3 = [
     "name",
     "[UnuseToken]",
     "timestamp",
+    "[UnuseToken]"
 ]
 PARSED_DICT3 = {"num1": "1", "name": "suzuki", "timestamp": "2022_03_02"}
 
 
 def test_generate_parser_pattern1():
-    parser = Parser(PARSING_RULE1)
+    parser = Parser(PARSING_RULE1, extension="wav")
     assert parser.parsing_keys == PARSING_KEYS1
 
 
 def test_parse_pattern1():
-    parser = Parser(PARSING_RULE1)
+    parser = Parser(PARSING_RULE1, extension="wav")
     parsed_dict = parser(INPUT_PATH1)
     assert parsed_dict == PARSED_DICT1
 
 
 def test_generate_parser_pattern2():
-    parser = Parser(PARSING_RULE2)
+    parser = Parser(PARSING_RULE2, extension="csv")
     assert parser.parsing_keys == PARSING_KEYS2
     assert parser.parsing_rule == CONVERTED_PARSING_RULE2
 
 
 def test_parse_pattern2():
-    parser = Parser(PARSING_RULE2)
+    parser = Parser(PARSING_RULE2, extension="csv")
     parsed_dict = parser(INPUT_PATH2)
     assert parsed_dict == PARSED_DICT2
 
 
 def test_generate_parser_pattern3():
-    parser = Parser(PARSING_RULE3)
+    parser = Parser(PARSING_RULE3, extension="csv")
     parser.update_rule(DETAIL_PARSING_RULE)
     assert parser.parsing_keys == PARSING_KEYS3
 
 
 def test_parse_pattern3():
-    parser = Parser(PARSING_RULE3)
+    parser = Parser(PARSING_RULE3, extension="csv")
     parser.update_rule(DETAIL_PARSING_RULE)
     parsed_dict = parser(INPUT_PATH3)
     assert parsed_dict == PARSED_DICT3
 
 
 def test_is_path_parsable():
-    parser = Parser(PARSING_RULE3)
+    parser = Parser(PARSING_RULE3, extension="csv")
 
     # Check for `IndexError` when parsing the file path with invalid `parsing_rule`.
     with pytest.raises(Exception) as e:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,9 +24,7 @@ PARSED_DICT1 = {
 
 INPUT_PATH2 = "/Origin/hoge1/fugasuzukipiyo_03.csv"
 PARSING_RULE2 = "{_}/hoge{num1}/fuga{name}piyo_{month}.csv"
-CONVERTED_PARSING_RULE2 = (
-    "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.{[UnuseToken]}"
-)
+CONVERTED_PARSING_RULE2 = "{_}/{[UnuseToken]}/{num1}/{[UnuseToken]}/{name}/{[UnuseToken]}_{month}.{[UnuseToken]}"
 PARSING_KEYS2 = [
     "_",
     "[UnuseToken]",
@@ -35,7 +33,7 @@ PARSING_KEYS2 = [
     "name",
     "[UnuseToken]",
     "month",
-    "[UnuseToken]"
+    "[UnuseToken]",
 ]
 PARSED_DICT2 = {"num1": "1", "name": "suzuki", "month": "03"}
 
@@ -50,7 +48,7 @@ PARSING_KEYS3 = [
     "name",
     "[UnuseToken]",
     "timestamp",
-    "[UnuseToken]"
+    "[UnuseToken]",
 ]
 PARSED_DICT3 = {"num1": "1", "name": "suzuki", "timestamp": "2022_03_02"}
 


### PR DESCRIPTION
close #91 #97 

# Motivation
* The parser class to behave stably
# Description of the changes
* For the stably behavior, sort a list of set
* To be able to parse the path with multiple "." in a path can also be parsed.
# Example