### PR TITLE
add message for search command

### DIFF
--- a/base/cli.py
+++ b/base/cli.py
@@ -682,6 +682,8 @@ def search_files(
                     f.write(output_csv)
             else:
                 click.echo(f"Sorry, export file type: {export} was not supprted yet...")
+        elif export is None and output is not None:
+            click.echo("\nPlease specify export file type. (e.g. --export json)")
 
 
 @main.command(name="invite", help="invite project member")


### PR DESCRIPTION
close #104

# Motivation
If only the -o option is specified in the base search command without the -e option, the results are not written to a file and a message must be printed.

# Description of the changes
- add a message for search -o  command executed w/o -e

# Example