### PR TITLE
Feature#106

### DIFF
--- a/base/cli.py
+++ b/base/cli.py
@@ -437,6 +437,9 @@ def import_dataset(project, directory, extension, parse, additional):
     click.echo("Check datafiles...")
     files = glob.glob(os.path.join(directory, "**", f"*.{extension}"), recursive=True)
     click.echo(f"found {len(files)} files with {extension} extension.")
+    assert (
+        len(files) > 0
+    ), "No datafiles found. Please check your directory and extension."
 
     if parse is None:
         sample_file_path = files[0].split(directory)[-1]


### PR DESCRIPTION
close #106 

# Motivation
When using `imoprt` command, if no file matching the extension of the condition is found, I get `IndexError: list index out of range`.

# Description of the changes
- add assert sentence for invalid imported data directory.

# Example